### PR TITLE
Add first integration test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose
+    - name: Run tests
+      run: cargo test
     - name: Run clippy
       run: cargo clippy -- -D warnings
     - name: Check formating

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,11 +338,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "docker-compose"
+version = "0.1.0"
+source = "git+https://github.com/antoine-de/rust-docker-compose.git?rev=1643ef5f3747c8c9cc5e1fa41ef5313990ea172f#1643ef5f3747c8c9cc5e1fa41ef5313990ea172f"
+dependencies = [
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -371,6 +397,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "escargot"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -946,6 +983,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -1644,6 +1704,8 @@ version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docker-compose 0.1.0 (git+https://github.com/antoine-de/rust-docker-compose.git?rev=1643ef5f3747c8c9cc5e1fa41ef5313990ea172f)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtfs-structures 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1659,6 +1721,11 @@ dependencies = [
  "thiserror 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "try-lock"
@@ -1855,6 +1922,7 @@ dependencies = [
 "checksum ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaa72766c3585a1f812a3387a7e2c6cab780f899c2f43ff6ea06c8d071fcbb36"
 "checksum anyhow 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "70a45816cea85cf69e3b34c7c99a13ca1654ee222029636a8674958043a2fac1"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
+"checksum assert_cmd 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2dc477793bd82ec39799b6f6b3df64938532fdf2ab0d49ef817eac65856a5a1e"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum backtrace 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "88fb679bc9af8fa639198790a77f52d345fe13656c08b43afa9424c206b731c6"
@@ -1887,12 +1955,15 @@ dependencies = [
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum docker-compose 0.1.0 (git+https://github.com/antoine-de/rust-docker-compose.git?rev=1643ef5f3747c8c9cc5e1fa41ef5313990ea172f)" = "<none>"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum escargot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ceb9adbf9874d5d028b5e4c5739d22b71988252b25c9c98fe7cf9738bee84597"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -1958,6 +2029,9 @@ dependencies = [
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
+"checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+"checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
 "checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
@@ -2033,6 +2107,7 @@ dependencies = [
 "checksum tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
+"checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,9 @@ thiserror = "1"
 anyhow = "1"
 lazy_static = "1.4"
 regex = "1.3"
+
+[dev-dependencies]
+docker-compose = { git = "https://github.com/antoine-de/rust-docker-compose.git", rev = "1643ef5f3747c8c9cc5e1fa41ef5313990ea172f" }
+#docker-compose = { git = "https://github.com/sfackler/rust-docker-compose.git" }
+assert_cmd = "0.11"
+

--- a/readme.md
+++ b/readme.md
@@ -27,3 +27,13 @@ Identifiers of entities can be the same across different producers. That is why 
 For instance, to import all the lines of the producer `Q4` from the local file `gtfs.zip`, run:
 
     cargo run --release --bin import_lines -- -p Q4 -i gtfs.zip
+
+## Testing
+
+The integration tests are based on [docker](https://www.docker.com) and [docker-compose](https://docs.docker.com/compose/), you need those tools installed.
+
+To run the tests run:
+
+    cargo test
+
+Note: docker need some root privileges, you might need to run this with more privileges (or [use other controversial means](https://docs.docker.com/install/linux/linux-postinstall/))

--- a/src/bin/import_lines.rs
+++ b/src/bin/import_lines.rs
@@ -31,7 +31,7 @@ fn main() {
     }
 
     let opt = Opt::from_args();
-    let mut client = Client::new(&opt.config).unwrap();
+    let mut client = Client::from_config_file(&opt.config).unwrap();
 
     if opt.producer.starts_with('Q') {
         info!("Searching the producer by id");

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,17 +46,21 @@ impl Config {
 }
 
 impl Client {
-    pub fn new<P: AsRef<std::path::Path>>(config_file: P) -> Result<Self, Error> {
+    pub fn from_config_file<P: AsRef<std::path::Path>>(config_file: P) -> Result<Self, Error> {
         let mut f = std::fs::File::open(config_file)?;
         let mut content = String::new();
         f.read_to_string(&mut content)?;
         let config = toml::from_str::<Config>(&content)?;
+        Self::new(config)
+    }
 
+    pub fn new(config: Config) -> Result<Self, Error> {
         Ok(Self {
             api: ApiClient::new(config.clone())?,
             sparql: SparqlClient::new(config),
         })
     }
+
     pub fn import_lines(
         &mut self,
         gtfs_filename: &str,

--- a/tests/minimal-docker-compose.yml
+++ b/tests/minimal-docker-compose.yml
@@ -1,0 +1,68 @@
+# TODO explain this docker-compose
+version: '3'
+
+services:
+  wikibase:
+    image: wikibase/wikibase:1.33-bundle
+    links:
+      - mysql
+    ports:
+     - "8123:80" # TODO: remove this binding, but since the container is restarted during startup it's not trivial
+    depends_on:
+    - mysql
+    - elasticsearch
+    restart: on-failure
+    environment:
+      - DB_SERVER=mysql:3306
+      - MW_ELASTIC_HOST=elasticsearch
+      - MW_ELASTIC_PORT=9200
+      # CONFIG - Change the default values below
+      - MW_ADMIN_NAME=WikibaseAdmin
+      - MW_ADMIN_PASS=WikibaseDockerAdminPass
+      - MW_ADMIN_EMAIL=admin@example.com
+      - MW_WG_SECRET_KEY=secretkey
+      # CONFIG - Change the default values below (should match mysql values in this file)
+      - DB_USER=wikiuser
+      - DB_PASS=sqlpass
+      - DB_NAME=my_wiki
+      - QS_PUBLIC_SCHEME_HOST_AND_PORT=http://localhost:9191
+  mysql:
+    image: mariadb:10.3
+    restart: always
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
+      # CONFIG - Change the default values below (should match values passed to wikibase)
+      MYSQL_DATABASE: 'my_wiki'
+      MYSQL_USER: 'wikiuser'
+      MYSQL_PASSWORD: 'sqlpass'
+  wdqs-frontend:
+    image: wikibase/wdqs-frontend:latest
+    ports:
+     - 80
+    depends_on:
+    - wdqs-proxy
+    environment:
+      - WIKIBASE_HOST=wikibase
+      - WDQS_HOST=wdqs-proxy
+  wdqs:
+    image: wikibase/wdqs:0.3.2
+    command: /runBlazegraph.sh
+    environment:
+      - WIKIBASE_HOST=wikibase
+      - WDQS_HOST=wdqs
+      - WDQS_PORT=9999
+    expose:
+      - 9999
+  wdqs-proxy:
+    image: wikibase/wdqs-proxy
+    environment:
+      - PROXY_PASS_HOST=wdqs:9999
+    ports:
+      - 80
+    depends_on:
+    - wdqs
+  elasticsearch:
+    image: wikibase/elasticsearch:5.6.14-extra
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -1,0 +1,24 @@
+mod utils;
+
+#[test]
+fn simple_test() {
+    let docker = utils::DockerContainerWrapper::new();
+
+    utils::run(&docker, "prepopulate", &[]);
+
+    let wikibase_client = utils::Wikibase::new(&docker);
+
+    // we first check that our exists method cannot find a unknown object
+    assert!(!wikibase_client.exists("pouet"));
+
+    // then we check the real objects
+    assert!(wikibase_client.exists("producer"));
+    // find properties too: "instance of"
+    // find properties too: "physical mode"
+    // find properties too: "gtfs short name"
+    // find properties too: "gtfs long name"
+    // find properties too: "gtfs id"
+    assert!(wikibase_client.exists("line"));
+    assert!(wikibase_client.exists("bus"));
+    assert!(wikibase_client.exists("bob the bus mapper"));
+}

--- a/tests/utils/command.rs
+++ b/tests/utils/command.rs
@@ -1,0 +1,25 @@
+use crate::utils::DockerContainerWrapper;
+use assert_cmd::cargo::CommandCargoExt;
+
+pub fn run(docker: &DockerContainerWrapper, target: &str, args: &[&str]) {
+    let api_port = docker
+        .port("wikibase", 80)
+        .expect("no port found for wikibase");
+    let sparql_port = docker
+        .port("wdqs-proxy", 80)
+        .expect("no port found for wdqs-proxy");
+    let api_endpoint = format!("http://localhost:{port}/api.php", port = api_port);
+    let sparql_endpoint = format!("http://localhost:{port}/bigdata/sparql", port = sparql_port);
+
+    let status = std::process::Command::cargo_bin(target)
+        .unwrap()
+        .arg("--api")
+        .arg(&api_endpoint)
+        .arg("--sparql")
+        .arg(&sparql_endpoint)
+        .args(args)
+        .status()
+        .unwrap();
+
+    assert!(status.success(), "`{}` failed {}", target, &status);
+}

--- a/tests/utils/docker_wrapper.rs
+++ b/tests/utils/docker_wrapper.rs
@@ -1,0 +1,69 @@
+use docker_compose::DockerComposition;
+
+fn init_log() {
+    if std::env::var("RUST_LOG").is_err() {
+        let mut builder = pretty_env_logger::formatted_builder();
+        builder.filter(None, log::LevelFilter::Info);
+        builder.init();
+    } else {
+        pretty_env_logger::init();
+    }
+}
+
+fn get_sparql_endpoint(c: &DockerComposition) -> String {
+    let port = c
+        .port("wdqs-proxy", 80)
+        .expect("no port found for wdqs-proxy");
+    format!("http://localhost:{port}/bigdata/sparql", port = port)
+}
+
+fn get_api_endpoint(c: &DockerComposition) -> String {
+    let port = c
+        .port("wikibase", 80)
+        .expect("impossible to get wikibase port");
+    format!("http://localhost:{port}/api.php", port = port)
+}
+
+// Check if wdqs is up. for this we do a http query
+fn check_wqs(c: &DockerComposition) -> bool {
+    let response = reqwest::get(&get_sparql_endpoint(c)).expect("invalid query");
+
+    response.error_for_status().is_ok()
+}
+
+fn check_wikibase(c: &DockerComposition) -> bool {
+    reqwest::get(&get_api_endpoint(c))
+        .and_then(|r| r.error_for_status())
+        .is_ok()
+}
+
+pub struct DockerContainerWrapper {
+    pub docker_compose: DockerComposition,
+    pub api_endpoint: String,
+    pub sparql_endpoint: String,
+}
+
+impl DockerContainerWrapper {
+    pub fn new() -> Self {
+        init_log();
+        let docker_compose = DockerComposition::builder()
+            .check(check_wqs)
+            .check(check_wikibase)
+            .timeout(std::time::Duration::from_secs(5 * 60))
+            .build("tests/minimal-docker-compose.yml")
+            .expect("unable to run docker compose");
+
+        Self {
+            api_endpoint: get_api_endpoint(&docker_compose),
+            sparql_endpoint: get_sparql_endpoint(&docker_compose),
+            docker_compose,
+        }
+    }
+}
+
+impl std::ops::Deref for DockerContainerWrapper {
+    type Target = DockerComposition;
+    fn deref(&self) -> &Self::Target {
+        &self.docker_compose
+    }
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,7 @@
+mod command;
+mod docker_wrapper;
+mod wikibase;
+
+pub use command::run;
+pub use docker_wrapper::DockerContainerWrapper;
+pub use wikibase::Wikibase;

--- a/tests/utils/wikibase.rs
+++ b/tests/utils/wikibase.rs
@@ -1,0 +1,27 @@
+//! Some utilities wikibase queries to ease tests
+use crate::utils::DockerContainerWrapper;
+
+pub struct Wikibase {
+    client: transitwiki::Client,
+}
+
+impl Wikibase {
+    pub fn new(docker: &DockerContainerWrapper) -> Self {
+        let config = transitwiki::client::Config {
+            api_endpoint: docker.api_endpoint.clone(),
+            sparql_endpoint: docker.sparql_endpoint.clone(),
+            ..Default::default()
+        };
+        Self {
+            client: transitwiki::Client::new(config).expect("impossible to create wikibase client"),
+        }
+    }
+
+    pub fn exists(&self, entity: &str) -> bool {
+        self.client
+            .api
+            .find_entity_id(entity)
+            .expect("invalid wikibase query")
+            .is_some()
+    }
+}


### PR DESCRIPTION
Add first shot at some docker integration tests.

The integration tests are based on [docker](https://www.docker.com) and [docker-compose](https://docs.docker.com/compose/), you need those tools installed.

The idea is, for each integration test, to pop a docker-compose with the full wikibase stack, and run some data import / test on this instance.

For the moment there is only the prepopulation step tested.