### PR TITLE
Test idempotence, and add some sparql tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +1722,7 @@ dependencies = [
  "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2005,6 +2011,7 @@ dependencies = [
 "checksum libflate 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "90c6f86f4b0caa347206f916f8b687b51d77c6ef8ff18d52dd007491fd580529"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c275b6ad54070ac2d665eef9197db647b32239c9d244bfb6f041a766d00da5b3"
+"checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ regex = "1.3"
 docker-compose = { git = "https://github.com/antoine-de/rust-docker-compose.git", rev = "1643ef5f3747c8c9cc5e1fa41ef5313990ea172f" }
 #docker-compose = { git = "https://github.com/sfackler/rust-docker-compose.git" }
 assert_cmd = "0.11"
+maplit = "1"
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -83,14 +83,18 @@ impl ApiClient {
     }
 
     /// search for all entities for a given english label
-    pub fn find_entities(&self, label: &str) -> Result<Vec<SearchResultItem>, ApiError> {
+    pub fn find_items(
+        &self,
+        object_type: ObjectType,
+        label: &str,
+    ) -> Result<Vec<SearchResultItem>, ApiError> {
         let res = self
             .get()
             .query(&[
                 ("action", "wbsearchentities"),
                 ("language", "en"),
                 ("search", label),
-                ("type", "item"),
+                ("type", &object_type.to_string()),
             ])
             .send()?
             .json::<SearchResponse>()?;
@@ -100,8 +104,12 @@ impl ApiClient {
 
     /// search for an entity by it's english label, and return it if it is uniq
     /// if multiple items match, return an error
-    pub fn find_entity_id(&self, label: &str) -> Result<Option<String>, ApiError> {
-        self.find_entities(label)
+    pub fn find_entity_id(
+        &self,
+        object_type: ObjectType,
+        label: &str,
+    ) -> Result<Option<String>, ApiError> {
+        self.find_items(object_type, label)
             .and_then(|entries| match entries.as_slice() {
                 [] => Ok(None),
                 [e] => Ok(Some(e.id.clone())),

--- a/src/bin/import_lines.rs
+++ b/src/bin/import_lines.rs
@@ -1,5 +1,6 @@
 use log::{debug, error, info, warn};
 use structopt::StructOpt;
+use transitwiki::api_client::ObjectType;
 use transitwiki::Client;
 
 #[derive(StructOpt, Debug)]
@@ -61,7 +62,7 @@ fn main() {
         }
     } else {
         info!("Searching the producer by name");
-        match client.api.find_entity_id(&opt.producer) {
+        match client.api.find_entity_id(ObjectType::Item, &opt.producer) {
             Ok(None) => warn!("We found no producer with the name {}", opt.producer),
             Ok(Some(id)) => info!("The following item match the search {}", id),
             Err(error) => error!("Could not find the entity by name: {}", error),

--- a/src/database_initializer.rs
+++ b/src/database_initializer.rs
@@ -18,7 +18,7 @@ fn get_or_create_item<'a>(
     };
 
     // for an item, we need to do a separate query to check if the item is already there
-    let id = if let Some(id) = client.find_entity_id(label)? {
+    let id = if let Some(id) = client.find_entity_id(ObjectType::Item, label)? {
         log::info!("item \"{}\" already exists with id {}", label, id);
         id
     } else {
@@ -123,5 +123,6 @@ pub fn initial_populate(
             topo_id.as_str(),
         )?;
     }
+
     Ok(config)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod api_client;
+pub mod api_client;
 mod api_structures;
 pub mod client;
 pub mod database_initializer;

--- a/src/sparql_client.rs
+++ b/src/sparql_client.rs
@@ -28,7 +28,7 @@ impl SparqlClient {
         Ok(json::parse(&response)?)
     }
 
-    fn sparql(
+    pub fn sparql(
         &self,
         variables: &[&str],
         where_clause: &str,

--- a/tests/minimal-docker-compose.yml
+++ b/tests/minimal-docker-compose.yml
@@ -61,8 +61,17 @@ services:
       - 80
     depends_on:
     - wdqs
+  wdqs-updater:
+    image: wikibase/wdqs:0.3.2
+    command: /runUpdate.sh
+    depends_on:
+    - wdqs
+    - wikibase
+    environment:
+     - WIKIBASE_HOST=wikibase
+     - WDQS_HOST=wdqs
+     - WDQS_PORT=9999
   elasticsearch:
     image: wikibase/elasticsearch:5.6.14-extra
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -1,4 +1,6 @@
 mod utils;
+use maplit::hashset;
+use transitwiki::api_client::{ObjectType, PropertyDataType};
 
 #[test]
 fn simple_test() {
@@ -9,16 +11,57 @@ fn simple_test() {
     let wikibase_client = utils::Wikibase::new(&docker);
 
     // we first check that our exists method cannot find a unknown object
-    assert!(!wikibase_client.exists("pouet"));
+    assert!(!wikibase_client.exists(ObjectType::Item, "pouet"));
 
     // then we check the real objects
-    assert!(wikibase_client.exists("producer"));
-    // find properties too: "instance of"
-    // find properties too: "physical mode"
-    // find properties too: "gtfs short name"
-    // find properties too: "gtfs long name"
-    // find properties too: "gtfs id"
-    assert!(wikibase_client.exists("line"));
-    assert!(wikibase_client.exists("bus"));
-    assert!(wikibase_client.exists("bob the bus mapper"));
+    assert!(wikibase_client.exists(
+        ObjectType::Property(PropertyDataType::String),
+        "instance of"
+    ));
+    assert!(wikibase_client.exists(
+        ObjectType::Property(PropertyDataType::String),
+        "physical mode"
+    ));
+    assert!(wikibase_client.exists(
+        ObjectType::Property(PropertyDataType::String),
+        "gtfs short name"
+    ));
+    assert!(wikibase_client.exists(
+        ObjectType::Property(PropertyDataType::String),
+        "gtfs long name"
+    ));
+    assert!(wikibase_client.exists(ObjectType::Property(PropertyDataType::String), "gtfs id"));
+    assert!(wikibase_client.exists(
+        ObjectType::Property(PropertyDataType::Item),
+        "Topo tools id"
+    ));
+
+    assert!(wikibase_client.exists(ObjectType::Item, "producer"));
+    assert!(wikibase_client.exists(ObjectType::Item, "line"));
+    assert!(wikibase_client.exists(ObjectType::Item, "bus"));
+    assert!(wikibase_client.exists(ObjectType::Item, "bob the bus mapper"));
+
+    // we check all the objects with a topo_id
+    assert_eq!(
+        wikibase_client.get_topo_objects(),
+        hashset![
+            "producer".to_owned(),
+            "line".to_owned(),
+            "bus".to_owned(),
+            "bob_the_bus_mapper".to_owned(),
+        ]
+    );
+
+    // We call again the prepopulate, there shouldn't be any differences
+    // since it should be idempotent
+    utils::run(&docker, "prepopulate", &[]);
+    assert_eq!(
+        wikibase_client.get_topo_objects(),
+        hashset![
+            "producer".to_owned(),
+            "line".to_owned(),
+            "bus".to_owned(),
+            "bob_the_bus_mapper".to_owned(),
+        ]
+    );
 }

--- a/tests/utils/command.rs
+++ b/tests/utils/command.rs
@@ -22,4 +22,11 @@ pub fn run(docker: &DockerContainerWrapper, target: &str, args: &[&str]) {
         .unwrap();
 
     assert!(status.success(), "`{}` failed {}", target, &status);
+
+    // TODO remove this wait
+    // The graph qb is asyncronously loaded, so the graphql query need some time
+    // before being able to query the data
+    // we need to find a way to trigger a refresh
+    log::info!("waiting a bit to let blazegraph refresh its data");
+    std::thread::sleep(std::time::Duration::from_secs(15));
 }

--- a/tests/utils/wikibase.rs
+++ b/tests/utils/wikibase.rs
@@ -1,5 +1,6 @@
 //! Some utilities wikibase queries to ease tests
 use crate::utils::DockerContainerWrapper;
+use transitwiki::api_client::ObjectType;
 
 pub struct Wikibase {
     client: transitwiki::Client,
@@ -17,11 +18,30 @@ impl Wikibase {
         }
     }
 
-    pub fn exists(&self, entity: &str) -> bool {
+    pub fn exists(&self, object_type: ObjectType, entity: &str) -> bool {
         self.client
             .api
-            .find_entity_id(entity)
+            .find_entity_id(object_type, entity)
             .expect("invalid wikibase query")
             .is_some()
+    }
+
+    /// get all objects with a topo id
+    pub fn get_topo_objects(&self) -> std::collections::HashSet<String> {
+        let r = self
+            .client
+            .sparql
+            .sparql(
+                &["topo_id"],
+                &format!(
+                    "?x wdt:{topo_id} ?topo_id",
+                    topo_id = "P1" //self.client.sparql.config.items.producer TODO remove this hardcoding
+                ),
+            )
+            .expect("invalid sparql query");
+
+        r.into_iter()
+            .map(|hashmap| hashmap["topo_id"].clone())
+            .collect()
     }
 }


### PR DESCRIPTION
prepopulate twice the db and check that no other objects are inserted.

to do this we do some graphql queries.

there is a big catcha to this:
the blazegraph db is asynchronously synchronized, so in the tests, for
the moment there is an uggly std::thread::sleep(15s), to make sure the
sparql engine can find the data...