### PR TITLE
Do not search items

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -62,7 +62,7 @@ impl std::string::ToString for ObjectType {
 
 pub struct ApiClient {
     client: reqwest::Client,
-    config: crate::client::EntitiesId,
+    pub config: crate::client::EntitiesId,
     endpoint: String,
     token: String,
 }

--- a/src/bin/prepopulate.rs
+++ b/src/bin/prepopulate.rs
@@ -6,12 +6,15 @@ struct Opt {
     /// Endpoint of the wikibase api
     #[structopt(short, long)]
     api: String,
+    /// Endpoint of the sparql query serive
+    #[structopt(short, long)]
+    sparql: String,
 }
 
 fn main() {
     transit_topo::log::init();
 
     let opt = Opt::from_args();
-    transit_topo::database_initializer::initial_populate(&opt.api)
+    transit_topo::database_initializer::initial_populate(&opt.api, &opt.sparql)
         .expect("impossible to populate wikibase");
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,6 +94,13 @@ impl Client {
         })
     }
 
+    pub fn new_without_config(api_endpoint: &str, sparql_enpoint: &str) -> Result<Self, Error> {
+        Ok(Self {
+            api: ApiClient::new(api_endpoint, Default::default())?,
+            sparql: SparqlClient::new_without_config(sparql_enpoint),
+        })
+    }
+
     pub fn import_gtfs(
         &self,
         gtfs_filename: &str,

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -119,14 +119,30 @@ fn create_producer(
 fn simple_test() {
     let docker = utils::DockerContainerWrapper::new();
 
-    utils::run("prepopulate", &["--api", &docker.api_endpoint]);
+    utils::run(
+        "prepopulate",
+        &[
+            "--api",
+            &docker.api_endpoint,
+            "--sparql",
+            &docker.sparql_endpoint,
+        ],
+    );
 
     let wikibase = utils::Wikibase::new(&docker);
     check_initiale_state(&wikibase);
 
     // We call again the prepopulate, there shouldn't be any differences
     // since it should be idempotent
-    utils::run("prepopulate", &["--api", &docker.api_endpoint]);
+    utils::run(
+        "prepopulate",
+        &[
+            "--api",
+            &docker.api_endpoint,
+            "--sparql",
+            &docker.sparql_endpoint,
+        ],
+    );
     check_initiale_state(&wikibase);
 
     // we then need to add a producer


### PR DESCRIPTION
for the moment the `get_or_create` function used the `/wbsearchentity` function that did text search on a label to check the existence of an item.

We do not want this (for example we might have many items with `"bus"` in their label).

We now then search by `topo_id` via sparql queries