### PR TITLE
add a entity cli

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,16 @@ Eg. to get the id of the item with the topo_id_id (`P1`) "route":
 
 Note: the `--claim` is directly passed to the sparql endpoint, so you need to know a bit sparql to use this.
 Note: The string must be quoted with `""`, the URL with `<>`
-Note: you can query a label with `--claim rdfs:label=\"<your label>\"@en`
+
+##### Examples uses
+
+* query entities with the label "bob" (note the `""` around the label, and the `@en` telling where looking for the english label):
+
+    cargo run --bin entities -- search --api <url of the wikibase api> --sparql <url of the sparql api> --claim 'rdfs:label="bob"@en'
+
+* query entities that have property P42 with value `https://transport.data.gouv.fr/datasets/5bfd2e81634f4122b3023260`, which is of type `url` (note the `<>` around the url):
+
+    cargo run --bin entities -- search --api <url of the wikibase api> --sparql <url of the sparql api> --claim 'P42=<https://transport.data.gouv.fr/datasets/5bfd2e81634f4122b3023260>'
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,20 @@ The `producer` needs to be already added to the transport TOPO instance.
 
     cargo run --release --bin import-gtfs -- --api <url of the wikibase api> --sparql <url of the sparql api> --producer <id of the producer> -i <path to gtfs.zip>
 
+#### Entity
+
+You can use the tool `entity` to search for entity in TOPO.
+
+This can be useful to explore or manage TOPO with cli tool.
+
+Eg. to get the id of the item with the topo_id_id (`P1`) "route":
+
+    cargo run --bin entities -- search --api <url of the wikibase api> --sparql <url of the sparql api> --claim 'P1="route"'
+
+Note: the `--claim` is directly passed to the sparql endpoint, so you need to know a bit sparql to use this.
+Note: The string must be quoted with `""`, the URL with `<>`
+Note: you can query a label with `--claim rdfs:label=\"<your label>\"@en`
+
 ## Contributing
 
 ### Building

--- a/src/bin/entities.rs
+++ b/src/bin/entities.rs
@@ -1,0 +1,97 @@
+use structopt::StructOpt;
+use transit_topo::Client;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "entities")]
+enum Opt {
+    Search {
+        /// Identifier of the topo id property
+        #[structopt(short, long, default_value = "P1")]
+        topo_id_id: String,
+
+        /// Endpoint of the wikibase api
+        #[structopt(short, long, default_value = "http://localhost:8181/api.php")]
+        api: String,
+
+        /// Endpoint of the sparql query serive
+        #[structopt(short, long, default_value = "http://localhost:8989/bigdata/sparql")]
+        sparql: String,
+
+        /// Extra claim with the form P42:foobar. Can be repeated
+        #[structopt(short, long = "claim")]
+        claims: Vec<String>,
+    },
+}
+
+fn parse_claims(claims: &[String]) -> Result<Vec<(String, String)>, anyhow::Error> {
+    let re = regex::Regex::new(r"^(.*)=(.*)$")?;
+    claims
+        .iter()
+        .map(|claim| {
+            let captures = re
+                .captures(&claim)
+                .ok_or_else(|| anyhow::anyhow!("Could not parse claim {}", claim))?;
+            Ok((captures[1].to_owned(), captures[2].to_owned()))
+        })
+        .collect()
+}
+
+fn search(
+    topo_id_id: &str,
+    api: &str,
+    sparql: &str,
+    claims: &[String],
+) -> Result<Vec<String>, anyhow::Error> {
+    use itertools::Itertools;
+    if claims.is_empty() {
+        return Err(anyhow::anyhow!("no claims provided, cannot find anything"));
+    }
+    let client = Client::new(api, sparql, topo_id_id)?;
+
+    let claims = parse_claims(claims)?;
+    let where_clause = format!(
+        "?item {claims}.",
+        claims = claims
+            .iter()
+            .map(|(p, v)| {
+                if p.contains(':') {
+                    // if the property contains a ':', we consider that we do not need to namespace it
+                    // it makes it possible to look for exemple by label: rdfs:label
+                    format!("{} {}", p, v)
+                } else {
+                    format!("wdt:{} {}", p, v)
+                }
+            })
+            .join("; ")
+    );
+
+    let res = client.sparql.sparql(&["?item"], &where_clause)?;
+
+    Ok(res
+        .into_iter()
+        .filter_map(|mut r| r.remove("item"))
+        .filter_map(|u| transit_topo::sparql_client::read_id_from_url(&u))
+        .collect())
+}
+
+fn main() {
+    // by default the logs are not activated, if you want some, provide RUST_LOG=<level>
+    // the logs are not activated since we want to use the stdout to pipe the results
+    pretty_env_logger::init();
+
+    let opt = Opt::from_args();
+
+    match opt {
+        Opt::Search {
+            topo_id_id,
+            api,
+            sparql,
+            claims,
+        } => {
+            let ids = search(&topo_id_id, &api, &sparql, &claims).expect("impossible to search:");
+            for id in ids {
+                println!("{}", id);
+            }
+        }
+    }
+}


### PR DESCRIPTION
for the moment there is only a search :

```bash
entitiy search --api <> --sparql <> --claim 'P1="route"'
```

this will output the id of all the item with the given label.

Later on we might be able to merge this with the create producer cli, and maybe enhance search to use the config.properties (maybe like `--claim @producer=bob` ?)

Note: The string must be quoted with `""`, the URL with `<>`
Note: I changed the regex parsing claims to be able to query a label with `--claim rdfs:label=\"<your label>\"@en`