### PR TITLE
add some context to the errors for better logs, and check http status

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,6 @@
 use crate::api_client::ApiClient;
 use crate::sparql_client::SparqlClient;
+use anyhow::Context;
 use anyhow::Error;
 use log::{info, warn};
 use serde::Deserialize;
@@ -87,7 +88,8 @@ impl EntitiesId {
 
 impl Client {
     pub fn new(api_endpoint: &str, sparql_enpoint: &str, topo_id_id: &str) -> Result<Self, Error> {
-        let sparql = SparqlClient::new(sparql_enpoint, topo_id_id)?;
+        let sparql = SparqlClient::new(sparql_enpoint, topo_id_id)
+            .context("impossible to create sparql client")?;
         Ok(Self {
             api: ApiClient::new(api_endpoint, sparql.config.clone())?,
             sparql,

--- a/src/sparql_client.rs
+++ b/src/sparql_client.rs
@@ -1,7 +1,6 @@
 use crate::client::{EntitiesId, Items, Properties};
 use anyhow::Context;
 use itertools::Itertools;
-use log::{debug, trace};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -105,7 +104,7 @@ impl SparqlClient {
         })
     }
     fn query(&self, query: &str) -> Result<json::JsonValue, SparqlError> {
-        debug!("Sparql query: {}", query);
+        log::debug!("Sparql query: {}", query);
         let response = self
             .client
             .get(&self.endpoint)
@@ -113,7 +112,7 @@ impl SparqlClient {
             .send()?
             .error_for_status()?
             .text()?;
-        debug!("Query response: {:?}", response);
+        log::trace!("Query response: {:?}", response);
         Ok(json::parse(&response)?)
     }
 
@@ -142,7 +141,7 @@ impl SparqlClient {
         producer_id: &str,
         gtfs_id: &str,
     ) -> Result<Vec<HashMap<String, String>>, SparqlError> {
-        trace!("Finding route {} of producer {}", gtfs_id, producer_id);
+        log::trace!("Finding route {} of producer {}", gtfs_id, producer_id);
         self.sparql(
             &[
                 "?route",
@@ -174,7 +173,7 @@ impl SparqlClient {
         producer_id: &str,
         stop: &gtfs_structures::Stop,
     ) -> Result<Vec<HashMap<String, String>>, SparqlError> {
-        trace!(
+        log::trace!(
             "Finding stop {} {} of producer {}",
             stop.name,
             stop.id,

--- a/src/sparql_client.rs
+++ b/src/sparql_client.rs
@@ -111,6 +111,7 @@ impl SparqlClient {
             .get(&self.endpoint)
             .query(&[("format", "json"), ("query", query)])
             .send()?
+            .error_for_status()?
             .text()?;
         debug!("Query response: {:?}", response);
         Ok(json::parse(&response)?)

--- a/src/sparql_client.rs
+++ b/src/sparql_client.rs
@@ -11,9 +11,9 @@ pub enum SparqlError {
     TopoIdNotFound(String),
     #[error("Several entities with topo id {0}")]
     DuplicatedTopoId(String),
-    #[error("error: {0}")]
+    #[error("Impossible to query: {0}")]
     ReqwestError(#[from] reqwest::Error),
-    #[error("error: {0}")]
+    #[error("Invalid json: {0}")]
     InvalidJsonError(#[from] json::Error),
     #[error("Error parsing the id {0} for entity with topo id {1}")]
     TopoInvalidId(String, String),

--- a/src/sparql_client.rs
+++ b/src/sparql_client.rs
@@ -1,4 +1,5 @@
 use crate::client::{EntitiesId, Items, Properties};
+use anyhow::Context;
 use itertools::Itertools;
 use log::{debug, trace};
 use std::collections::HashMap;
@@ -44,7 +45,7 @@ impl SparqlClient {
     }
 
     /// create a new client and discory all the base entities id
-    pub fn new(endpoint: &str, topo_id_id: &str) -> Result<Self, SparqlError> {
+    pub fn new(endpoint: &str, topo_id_id: &str) -> Result<Self, anyhow::Error> {
         let mut client = Self {
             client: reqwest::Client::new(),
             endpoint: endpoint.to_owned(),
@@ -57,7 +58,9 @@ impl SparqlClient {
             },
         };
 
-        client.config = client.discover_config()?;
+        client.config = client
+            .discover_config()
+            .context("impossible to discovery config")?;
         Ok(client)
     }
 


### PR DESCRIPTION
remove specific error in `sparql_client::new` for better errors.
Also add a `raise_for_status` in `reqwest`, that checks the http status before trying to deserialize.


now a `502` on the sparql endpoint will be logged as:

```
thread 'main' panicked at 'impossible to search:: impossible to create client

Caused by:
    0: impossible to create sparql client
    1: impossible to discovery config
    2: Impossible to query: http://localhost:8989/bigdata/sparql?format=json&query=SELECT+%3Fitem_id+WHERE+%7B+%3Fitem_id+wdt%3AP1+%27physical_mode%27+SERVICE+wikibase%3Alabel+%7B+bd%3AserviceParam+wikibase%3Alanguage+%22en%22.+%7D+%7D: Server Error: 502 Bad Gateway
    3: http://localhost:8989/bigdata/sparql?format=json&query=SELECT+%3Fitem_id+WHERE+%7B+%3Fitem_id+wdt%3AP1+%27physical_mode%27+SERVICE+wikibase%3Alabel+%7B+bd%3AserviceParam+wikibase%3Alanguage+%22en%22.+%7D+%7D: Server Error: 502 Bad Gateway
', src/libcore/result.rs:1084:5
```

instead of :


```
thread 'main' panicked at 'impossible to search:: Unexpected character: < at (1:1)`
```