### PR TITLE
Add coord to stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,11 +705,6 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "json"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1777,6 @@ dependencies = [
  "git-version 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtfs-structures 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2071,7 +2065,6 @@ dependencies = [
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum json 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3ca41abbeb7615d56322a984e63be5e5d0a117dfaca86c14393e32a762ccac1"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ ansi_term = "0.12"
 gtfs-structures = "0.15"
 Inflector = { version="0.11", default-features=false }
 itertools = "0.8"
-json = "0.12"
 log = "0.4"
 pretty_env_logger = "0.3"
 reqwest = "0.9"

--- a/src/clients/api_client.rs
+++ b/src/clients/api_client.rs
@@ -1,8 +1,8 @@
 use crate::clients::api_structures::*;
 use crate::entity;
 use anyhow::anyhow;
-use json::object;
 use regex::Regex;
+use serde_json::json;
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -132,27 +132,28 @@ impl ApiClient {
         &self,
         object_type: ObjectType,
         label: &str,
-        extra_claims: Vec<Option<json::JsonValue>>,
+        extra_claims: Vec<Option<serde_json::Value>>,
     ) -> Result<String, ApiError> {
-        let labels = object! {
-            "en" => object!{
-                "language" => "en",
-                "value" => label
+        let labels = json!({
+            "en": {
+                "language": "en",
+                "value": label
             }
-        };
+        });
         let extra_claims: Vec<_> = extra_claims.into_iter().filter_map(|v| v).collect();
 
-        let claims = json::stringify(match &object_type {
-            ObjectType::Property(datatype) => object! {
-                "labels" => labels,
-                "datatype" => datatype.to_string(),
-                "claims" => extra_claims,
-            },
-            ObjectType::Item => object! {
-                "labels" => labels,
-                "claims" => extra_claims,
-            },
-        });
+        let json_claims = match &object_type {
+            ObjectType::Property(datatype) => json!({
+                "labels": labels,
+                "datatype": datatype.to_string(),
+                "claims": extra_claims,
+            }),
+            ObjectType::Item => json!( {
+                "labels": labels,
+                "claims": extra_claims,
+            }),
+        };
+        let claims = serde_json::to_string(&json_claims)?;
 
         log::trace!("claims: {}", claims);
         let mut res = self
@@ -216,7 +217,7 @@ impl ApiClient {
     pub fn create_item(
         &self,
         label: &str,
-        extra_claims: Vec<Option<json::JsonValue>>,
+        extra_claims: Vec<Option<serde_json::Value>>,
     ) -> Result<String, ApiError> {
         self.create_object(ObjectType::Item, label, extra_claims)
     }
@@ -237,10 +238,10 @@ impl ApiClient {
     pub fn add_claims(
         &self,
         entity_id: &str,
-        claims: Vec<Option<json::JsonValue>>,
+        claims: Vec<Option<serde_json::Value>>,
     ) -> Result<(), ApiError> {
         let claims: Vec<_> = claims.into_iter().filter_map(|v| v).collect();
-        let claims = json::stringify(object! { "claims" => claims});
+        let claims = serde_json::to_string(&json!({ "claims": claims }))?;
         log::trace!("claims: {}", claims);
         let mut res = self
             .client
@@ -261,33 +262,35 @@ impl ApiClient {
     }
 }
 
-pub fn claim(property: &str, datavalue: json::JsonValue) -> Option<json::JsonValue> {
-    Some(object! {
-        "mainsnak" => object!{
-            "snaktype" => "value",
-            "property" => property,
-            "datavalue" => datavalue
+pub fn claim(property: &str, datavalue: serde_json::Value) -> Option<serde_json::Value> {
+    Some(json!({
+        "mainsnak": {
+            "snaktype": "value",
+            "property": property,
+            "datavalue": datavalue
         },
-        "type" => "statement",
-        "rank" => "normal"
-    })
+        "type": "statement",
+        "rank": "normal"
+    }))
 }
-pub fn claim_string(property: &str, value: &str) -> Option<json::JsonValue> {
+pub fn claim_string(property: &str, value: &str) -> Option<serde_json::Value> {
     let value = value.trim();
     if value.is_empty() {
         // it's impossible to add a claim with an empty value, so we skip it
         None
     } else {
-        claim(property, object! { "value" => value, "type" => "string" })
+        claim(property, json!({ "value": value, "type": "string" }))
     }
 }
 
-pub fn claim_item(property: &str, id: &str) -> Option<json::JsonValue> {
+pub fn claim_item(property: &str, id: &str) -> Option<serde_json::Value> {
     claim(
         property,
-        object! {
-            "value" => object!{ "entity-type" => "item", "id" => id },
-            "type" => "wikibase-entityid",
-        },
+        json!({
+            "value":{ "entity-type": "item", "id": id },
+            "type": "wikibase-entityid",
+        }),
+    )
+}
     )
 }

--- a/src/clients/api_client.rs
+++ b/src/clients/api_client.rs
@@ -122,6 +122,13 @@ impl ApiClient {
                         let val = match data_value {
                             Datavalue::String(s) => entity::PropertyValue::String(s),
                             Datavalue::Item { id } => entity::PropertyValue::Item(id),
+                            Datavalue::Coord {
+                                latitude,
+                                longitude,
+                            } => entity::PropertyValue::Coord {
+                                latitude,
+                                longitude,
+                            },
                         };
                         Ok((prop_id, val))
                     })
@@ -302,6 +309,7 @@ pub fn claim_coord(property: &str, lon: f64, lat: f64) -> Option<serde_json::Val
             "value": {
                 "latitude": lat,
                 "longitude": lon,
+                "precision": 0.000_001,
                 "globe": "http://www.wikidata.org/entity/Q2"
             },
             "type": "globecoordinate",

--- a/src/clients/api_client.rs
+++ b/src/clients/api_client.rs
@@ -34,6 +34,7 @@ pub enum PropertyDataType {
     String,
     Url,
     Item,
+    Coord,
 }
 
 impl std::string::ToString for PropertyDataType {
@@ -42,6 +43,7 @@ impl std::string::ToString for PropertyDataType {
             Self::String => "string".to_owned(),
             Self::Item => "wikibase-item".to_owned(),
             Self::Url => "url".to_owned(),
+            Self::Coord => "globe-coordinate".to_owned(),
         }
     }
 }
@@ -292,5 +294,17 @@ pub fn claim_item(property: &str, id: &str) -> Option<serde_json::Value> {
         }),
     )
 }
+
+pub fn claim_coord(property: &str, lon: f64, lat: f64) -> Option<serde_json::Value> {
+    claim(
+        property,
+        json!({
+            "value": {
+                "latitude": lat,
+                "longitude": lon,
+                "globe": "http://www.wikidata.org/entity/Q2"
+            },
+            "type": "globecoordinate",
+        }),
     )
 }

--- a/src/clients/api_structures.rs
+++ b/src/clients/api_structures.rs
@@ -13,6 +13,8 @@ pub enum Datavalue {
     String(String),
     #[serde(rename = "wikibase-entityid")]
     Item { id: String },
+    #[serde(rename = "globecoordinate")]
+    Coord { latitude: f64, longitude: f64 },
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/database_initializer.rs
+++ b/src/database_initializer.rs
@@ -137,6 +137,7 @@ pub fn initial_populate(api_endpoint: &str, sparql_endpoint: &str) -> Result<Ent
             tool_version: create_prop("Tool version", PropertyDataType::String)?,
             part_of: create_prop("Part of", PropertyDataType::Item)?,
             connecting_line: create_prop("Connecting line", PropertyDataType::Item)?,
+            coordinate_location: create_prop("Coordinate location", PropertyDataType::Coord)?,
         },
         items: Items {
             physical_mode: physical_mode.to_owned(),

--- a/src/database_initializer.rs
+++ b/src/database_initializer.rs
@@ -47,7 +47,7 @@ fn get_id_by_topo_id(client: &Client, topo_id: &str) -> Result<Option<String>, a
 fn get_or_create_item(
     client: &Client,
     label: &str,
-    claims: &[Option<json::JsonValue>],
+    claims: &[Option<serde_json::Value>],
 ) -> Result<String, Error> {
     let mut claims = Vec::from(claims);
     let topo_id = label.to_snake_case();

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -2,6 +2,7 @@
 pub enum PropertyValue {
     String(String),
     Item(String),
+    Coord { latitude: f64, longitude: f64 },
 }
 
 impl PropertyValue {
@@ -9,6 +10,8 @@ impl PropertyValue {
         match self {
             PropertyValue::String(e) => e,
             PropertyValue::Item(e) => e,
+            // Note: this method is used only in tests, we can panic
+            PropertyValue::Coord { .. } => panic!("unable to convert coord to string"),
         }
     }
 }

--- a/src/known_entities.rs
+++ b/src/known_entities.rs
@@ -8,24 +8,40 @@ pub struct EntitiesId {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Properties {
+    /// The Topo ID is used as an internal ID based on the name of each known properties/items
+    /// It makes it possible to query the DB to get all the known entities
     pub topo_id_id: String,
+    /// Link to the data Producer
     pub produced_by: String,
+    /// Type of the entity
     pub instance_of: String,
+    /// Basic name in the GTFS
     pub gtfs_name: String,
+    /// Short name in the GTFS
     pub gtfs_short_name: String,
+    /// Long name in the GTFS
     pub gtfs_long_name: String,
+    /// ID in the GTFS
     pub gtfs_id: String,
+    /// Link to the Datasource
     pub data_source: String,
     pub first_seen_in: String,
+    /// Path of the file used to import the data
     pub source: String,
+    /// Format of the file used to import the data
     pub file_format: String,
+    /// sha256 of the file used to import the data
     pub sha_256: String,
+    /// Link to the Physical mode of the entity
     pub has_physical_mode: String,
+    /// version of the tool used to import the entities
     pub tool_version: String,
     /// Shows a relation of inclusion: a stop point is part_of a stop area
     pub part_of: String,
     /// Shows that a stop is connected to a line https://www.wikidata.org/wiki/Property:P81
     pub connecting_line: String,
+    /// The coordinate of an entity
+    pub coordinate_location: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/topo_query.rs
+++ b/src/topo_query.rs
@@ -182,6 +182,7 @@ fn discover_known_entities(
             tool_version: find_entity_by_topo_id(client, "tool_version", topo_id_id)?,
             part_of: find_entity_by_topo_id(client, "part_of", topo_id_id)?,
             connecting_line: find_entity_by_topo_id(client, "connecting_line", topo_id_id)?,
+            coordinate_location: find_entity_by_topo_id(client, "coordinate_location", topo_id_id)?,
         },
     })
 }

--- a/src/topo_writer.rs
+++ b/src/topo_writer.rs
@@ -1,4 +1,4 @@
-use crate::clients::api_client::{claim_item, claim_string, ApiClient};
+use crate::clients::api_client::{claim_coord, claim_item, claim_string, ApiClient};
 use crate::clients::ObjectType;
 use crate::known_entities::EntitiesId;
 use anyhow::Context;
@@ -95,6 +95,11 @@ impl TopoWriter {
             claim_string(&self.known_entities.properties.gtfs_id, &stop.id),
             claim_item(&self.known_entities.properties.data_source, data_source_id),
             claim_string(&self.known_entities.properties.gtfs_name, &stop.name),
+            claim_coord(
+                &self.known_entities.properties.coordinate_location,
+                stop.longitude,
+                stop.latitude,
+            ),
         ];
 
         self.client

--- a/tests/simple_test.rs
+++ b/tests/simple_test.rs
@@ -25,6 +25,7 @@ fn check_initiale_state(wikibase: &utils::Wikibase) {
             "bus".to_owned(),
             "cable_car".to_owned(),
             "connecting_line".to_owned(),
+            "coordinate_location".to_owned(),
             "data_source".to_owned(),
             "ferry".to_owned(),
             "file_format".to_owned(),


### PR DESCRIPTION
assign their coord to each stops.

Coupled with the custom rendering of sparql queries, this makes it possible to easily have a map for topo like (with the example GTFS):

![image](https://user-images.githubusercontent.com/3987698/69873003-0626bc00-12af-11ea-94c7-604662ce33a0.png)


Note: the sparql query to get this is
```sparql
#defaultView:Map
select * where {
  ?item wdt:P17 ?coord
}
```

also closes #41 because I was bothered by it