### PR TITLE
use linked-wiki image in local

### DIFF
--- a/local-compose.yml
+++ b/local-compose.yml
@@ -5,6 +5,7 @@ version: '3'
 
 services:
   wikibase:
+    image: antoinede/linked-wiki
     ports:
      - "8181:80"
     volumes:


### PR DESCRIPTION
work on #27 
Use [LinkedWiki](https://www.mediawiki.org/wiki/Extension:LinkedWiki) as a wikimedia extension. It uses a docker image [automatically build](https://hub.docker.com/repository/docker/antoinede/linked-wiki) in docker hub

it makes it possible to add sparql snippet like:

```
== positions des arrêts ==

{{#sparql:
SELECT ?lat ?long ?oLabel  WHERE {
  ?o p:P17 ?coord.
  ?coord psv:P17 ?coord_value.
  ?coord_value wikibase:geoLatitude ?lat;
    wikibase:geoLongitude ?long.
  SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
}
|endpoint=http://localhost:8989/bigdata/sparql
|chart=leaflet.visualization.Map
|options=width=100%!height=500px
|log=2
}}

```
to do:
![image](https://user-images.githubusercontent.com/3987698/69989998-bf4df600-153c-11ea-95e9-187709767be3.png)




We sure won't be able to display all stops in a map, but it makes it
possible to show a bit what's inside the topo instance