### PR TITLE
Add a mechanism to override the existing stops

### DIFF
--- a/src/bin/import-gtfs.rs
+++ b/src/bin/import-gtfs.rs
@@ -26,6 +26,12 @@ struct Opt {
     /// Endpoint of the sparql query serive
     #[structopt(short, long, default_value = "http://localhost:8989/bigdata/sparql")]
     sparql: String,
+
+    /// Override existing objects
+    /// This is to be used when the importing tool has been updated
+    /// and you want to force the update of the already inserted items
+    #[structopt(long)]
+    override_existing: bool,
 }
 
 fn main() {
@@ -43,6 +49,11 @@ fn main() {
     log::info!("Found the producer “{}”", &producer_label);
     log::info!("Starting the importation of lines");
     importer
-        .import_gtfs(&opt.gtfs_filename, &opt.producer, &producer_label)
+        .import_gtfs(
+            &opt.gtfs_filename,
+            &opt.producer,
+            &producer_label,
+            opt.override_existing,
+        )
         .expect("unable to import");
 }

--- a/src/clients/api_client.rs
+++ b/src/clients/api_client.rs
@@ -1,10 +1,10 @@
 use crate::clients::api_structures::*;
+use crate::clients::ApiError;
 use crate::entity;
 use anyhow::anyhow;
 use regex::Regex;
 use serde_json::json;
 use std::collections::HashMap;
-use thiserror::Error;
 
 const WIKIBASE_LABEL_CONFLICT: &str = "wikibase-validator-label-conflict";
 
@@ -12,22 +12,6 @@ lazy_static::lazy_static! {
     // the message in the api response is in the form "[[Property:P1|P1]]"
     // and in this example we want to extract "P1"
     static ref LABEL_CONFLICT_REGEX: Regex = Regex::new(r#"\[\[.+\|(.+)\]\]"#).unwrap();
-}
-
-#[derive(Debug, Error)]
-pub enum ApiError {
-    #[error("{label} already exists, id = {id}")]
-    PropertyAlreadyExists { label: String, id: String },
-    #[error("Several items with label {0}")]
-    TooManyItems(String),
-    #[error("Cannot find entiy {0}")]
-    EntityNotFound(String),
-    #[error("error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
-    #[error("error: {0}")]
-    InvalidJsonError(#[from] serde_json::Error),
-    #[error("error: {0}")]
-    GenericError(String),
 }
 
 pub enum PropertyDataType {
@@ -176,7 +160,8 @@ impl ApiClient {
                 ("format", "json"),
             ])
             .form(&[("token", &self.token), ("data", &claims)])
-            .send()?;
+            .send()?
+            .error_for_status()?;
 
         log::trace!("Response headers: {:#?}", res);
         let body = res.text()?;
@@ -238,6 +223,7 @@ impl ApiClient {
             .get()
             .query(&[("action", "wbgetentities"), ("ids", id), ("format", "json")])
             .send()?
+            .error_for_status()?
             .json::<serde_json::Value>()?;
 
         res.pointer(&format!("/entities/{}/labels/en/value", id))
@@ -263,12 +249,13 @@ impl ApiClient {
                 ("format", "json"),
             ])
             .form(&[("token", &self.token), ("data", &claims)])
-            .send()?;
+            .send()?
+            .error_for_status()?;
 
         log::trace!("Response headers: {:#?}", res);
         let body = res.text()?;
         log::trace!("Response body: {:#?}", body);
-        serde_json::from_str::<ApiResponse>(&body)?;
+        serde_json::from_str::<ApiResponse>(&body)?.error_for_status()?;
         Ok(())
     }
 }

--- a/src/clients/api_error.rs
+++ b/src/clients/api_error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ApiError {
+    #[error("{label} already exists, id = {id}")]
+    PropertyAlreadyExists { label: String, id: String },
+    #[error("Several items with label {0}")]
+    TooManyItems(String),
+    #[error("Cannot find entiy {0}")]
+    EntityNotFound(String),
+    #[error("error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("error: {0}")]
+    InvalidJsonError(#[from] serde_json::Error),
+    #[error("error: {0}")]
+    GenericError(String),
+}

--- a/src/clients/mod.rs
+++ b/src/clients/mod.rs
@@ -1,6 +1,8 @@
 pub mod api_client;
+mod api_error;
 mod api_structures;
 pub mod sparql_client;
 
 pub use api_client::{ApiClient, ObjectType, PropertyDataType};
+pub use api_error::ApiError;
 pub use sparql_client::SparqlClient;

--- a/src/database_initializer.rs
+++ b/src/database_initializer.rs
@@ -1,6 +1,7 @@
-use crate::clients::api_client::{claim_item, claim_string, ApiError};
-use crate::clients::{sparql_client, SparqlClient};
-use crate::clients::{ApiClient, ObjectType, PropertyDataType};
+use crate::clients::api_client::{claim_item, claim_string};
+use crate::clients::{
+    sparql_client, ApiClient, ApiError, ObjectType, PropertyDataType, SparqlClient,
+};
 use crate::known_entities::{EntitiesId, Items, Properties};
 use anyhow::Error;
 use inflector::Inflector;

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -56,8 +56,8 @@ impl GtfsImporter {
             .values()
             .map(|route| {
                 let r = self.query.find_route(&producer_id, &route.id)?;
-                match r.as_slice() {
-                    [] => {
+                match r {
+                    None => {
                         info!(
                             "Route “{}” ({}) does not exist, inserting",
                             route.long_name, route.short_name
@@ -67,18 +67,13 @@ impl GtfsImporter {
                                 .insert_route(&route, &data_source_id, producer_name)?;
                         Ok((route.id.to_owned(), wikibase_id))
                     }
-                    [e] => {
+                    Some(route_id) => {
                         info!(
                             "Route “{}” ({}) already exists with id {}, skipping",
-                            route.long_name, route.short_name, e["route"]
+                            route.long_name, route.short_name, route_id
                         );
-                        Ok((route.id.to_owned(), e["route"].to_owned()))
+                        Ok((route.id.to_owned(), route_id.to_owned()))
                     }
-                    _ => Err(anyhow::anyhow!(
-                        "Route “{}” ({}) exists many times. Something is not right",
-                        route.long_name,
-                        route.short_name
-                    )),
                 }
             })
             .collect()
@@ -94,8 +89,8 @@ impl GtfsImporter {
             .values()
             .map(|stop| {
                 let s = self.query.find_stop(&producer_id, &stop)?;
-                match s.as_slice() {
-                    [] => {
+                match s {
+                    None => {
                         info!(
                             "Stop “{}” ({}) does not exist, inserting",
                             stop.name, stop.id
@@ -103,18 +98,13 @@ impl GtfsImporter {
                         let wikibase_id = self.writer.insert_stop(&stop, &data_source_id)?;
                         Ok((stop.id.to_owned(), wikibase_id))
                     }
-                    [e] => {
+                    Some(stop_id) => {
                         info!(
                             "Stop “{}” ({}) already exists with id {}, skipping",
-                            stop.name, stop.id, e["stop"]
+                            stop.name, stop.id, stop_id
                         );
-                        Ok((stop.id.to_owned(), e["stop"].to_owned()))
+                        Ok((stop.id.to_owned(), stop_id.to_owned()))
                     }
-                    _ => Err(anyhow::anyhow!(
-                        "Stop “{}” ({}) exists many times. Something is not right",
-                        stop.name,
-                        stop.id
-                    )),
                 }
             })
             .collect()


### PR DESCRIPTION
A bit related to the 1. problem in #57 .
For the moment we have no good policy to update the DB without wipeouting it.

This adds a dumb mechanisms, it adds a cli arg `--override-existing` that makes it possible to update the existing stops (only stop for the  moment, but it would have to be extended to the other objects).

At the shot term, this will makes it possible to update the current DB to add position.

This PR also add a check on the api response for error, since there was silent errors returned by the API since the status code is 200.even for errors.

I tracked this issue since I did not understand how we were not endlessly adding link stop->parent_stop and stop->route at each run of the importer.
With the [api bug repared](https://github.com/etalab/transport-topo/commit/c5e90ba666736f7cf8f61ea134e6529383fd2434), we now have the non idempotent link adding :stuck_out_tongue_winking_eye: (but that will be for another PR, it has been tracked in #58 , we need to think about how to handle this)