### PR TITLE
add a app_id in the logs

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -1,7 +1,22 @@
+use std::io::Write;
+
 pub fn init() {
-    if std::env::var("RUST_LOG").is_err() {
+    let log_level = std::env::var("RUST_LOG");
+    let app_id = std::env::var("APP_ID");
+    if log_level.is_err() || app_id.is_ok() {
         let mut builder = pretty_env_logger::formatted_builder();
-        builder.filter(None, log::LevelFilter::Info);
+        if let Ok(app_id) = app_id {
+            // APP_ID is used to output an id while logging
+            builder.format(move |buf, record| {
+                writeln!(buf, "[{}] {} - {}", app_id, record.level(), record.args())
+            });
+        }
+
+        if let Ok(s) = std::env::var("RUST_LOG") {
+            builder.parse_filters(&s);
+        } else {
+            builder.filter(None, log::LevelFilter::Info);
+        }
         builder.init();
     } else {
         pretty_env_logger::init();


### PR DESCRIPTION
if the run are parallelized, it's easier to track them with an APP_ID

needed by https://github.com/etalab/transport-topo-tools/pull/3